### PR TITLE
Do not reuse parameters in vsprintf()

### DIFF
--- a/src/Sprintf.php
+++ b/src/Sprintf.php
@@ -12,8 +12,7 @@ class Sprintf
      */
     public static function sprintf($format, array $parameters)
     {
-        $named_param_map = self::getNamedParamMap($parameters);
-
+        $parsed_parameters = [];
         $replacement_sets = [];
         $matches = [];
         $pattern = '
@@ -32,13 +31,14 @@ class Sprintf
                 $percent_signs = $match[1];
                 $named_param = $match[2];
 
-                if (!array_key_exists($named_param, $named_param_map)) {
+                if (!array_key_exists($named_param, $parameters)) {
                     throw new Exception(
                         "The '{$named_param}' parameter was in the format string but was not provided"
                     );
                 }
 
-                $replacement_sets[$match[0]] = "{$percent_signs}{$named_param_map[$named_param]}";
+                $replacement_sets[$match[0]] = "{$percent_signs}";
+                $parsed_parameters[] = $parameters[$named_param];
             }
         }
 
@@ -46,22 +46,6 @@ class Sprintf
         $replacements = array_values($replacement_sets);
         $parsed_format = str_replace($searches, $replacements, $format);
 
-        return vsprintf($parsed_format, array_values($parameters));
-    }
-
-    /**
-     * @param array $named_params
-     * @return array
-     */
-    private static function getNamedParamMap(array $named_params)
-    {
-        $param_map = [];
-        $param_number = 1;
-        foreach ($named_params as $param_name => $param_value) {
-            $param_map[$param_name] = "{$param_number}\$";
-            ++$param_number;
-        }
-
-        return $param_map;
+        return vsprintf($parsed_format, $parsed_parameters);
     }
 }


### PR DESCRIPTION
We want to duplicate the parameters in preparation
of implementing middleware, which will be able to
treat each occurrence of a named-parameter
differently