### PR TITLE
Enforce sprintf directive format

### DIFF
--- a/src/Sprintf.php
+++ b/src/Sprintf.php
@@ -16,7 +16,7 @@ class Sprintf
         $replacement_sets = [];
         $matches = [];
         $pattern = '
-            /
+            @
                 (
                     (?:^|[^%])
                     (?:%%)*%
@@ -24,12 +24,41 @@ class Sprintf
                 \( # literal open paren
                     ([a-zA-Z_][a-zA-Z0-9_\-]*?) # 2: the name of the param 
                 \) # literal close paren
-            /mx
+
+                (
+                    (?:
+                        # standard sprintf format. reference http://php.net/sprintf
+                        [+]?                # an optional +/- sign specifier
+
+                        (?:[ 0]|\'.)?       # an optional space/zero padding specifier or
+                                            # alternative padding character prefixed by a single quote
+
+                        [\-]?               # an optional alignment specifier
+                                            # ("-" for left-justified; right-justified otherwise)
+
+                        \d*                 # an optional width specifier
+
+                        (?:\.(?:.?\d+)?)?   # an optional precision specifier
+                                            # (a dot "." followed by an optional number, with an optional
+                                            # padding character in between the dot and the number)
+
+                        [bcdeEfFgGosuxX]    # the type specifier
+                    )?
+
+                ) # 3: the standard sprintf format
+            @mx
         ';
         if (preg_match_all($pattern, $format, $matches, PREG_SET_ORDER)) {
             foreach ($matches as $match) {
                 $percent_signs = $match[1];
                 $named_param = $match[2];
+                $sprintf_format = $match[3];
+
+                // if it is not a valid sprintf directive, escape the %
+                if (!$sprintf_format) {
+                    $replacement_sets[$match[0]] = "{$percent_signs}%({$named_param})";
+                    continue;
+                }
 
                 if (!array_key_exists($named_param, $parameters)) {
                     throw new Exception(
@@ -37,7 +66,7 @@ class Sprintf
                     );
                 }
 
-                $replacement_sets[$match[0]] = "{$percent_signs}";
+                $replacement_sets[$match[0]] = "{$percent_signs}{$sprintf_format}";
                 $parsed_parameters[] = $parameters[$named_param];
             }
         }

--- a/tests/src/SprintfTest.php
+++ b/tests/src/SprintfTest.php
@@ -26,12 +26,27 @@ class SprintfTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider provideNamedToUnnamedTranslatedTestCases
+     * @param string $unnamed_format
+     * @param string $named_format
+     * @param string $value
+     */
+    public function testNamedToUnnamedTranslatedCases($unnamed_format, $named_format, $value)
+    {
+        $this->assertEquals(
+            sprintf($unnamed_format, $value),
+            Sprintf::sprintf($named_format, ['value' => $value]),
+            "Test that advanced cases can use format '{$named_format}'"
+        );
+    }
+
+    /**
      * @expectedException \Lstr\Sprintf\Exception
      */
     public function testUnprovidedNamedParametersThrowAnException()
     {
         Sprintf::sprintf(
-            'Hello %(missing_param)',
+            'Hello %(missing_param)s',
             ['full_name' => 'There']
         );
     }
@@ -49,16 +64,34 @@ class SprintfTest extends PHPUnit_Framework_TestCase
                 ['first_name' => 'Matt', 'last_name' => 'Light'],
             ],
             [
+                "Test that named parameters are only recognized if sprintf directive is valid",
+                'Hello %(first_name) Light',
+                'Hello %(first_name) %(last_name)s',
+                ['first_name' => 'Matt', 'last_name' => 'Light'],
+            ],
+            [
+                "Test that no parameters are required",
+                'Hello %(first_name)',
+                'Hello %(first_name)',
+                [],
+            ],
+            [
                 "Test that a floating point number can be formatted",
                 'PI is approximately 3.14159',
                 'PI is approximately %(pi).5f',
                 ['pi' => pi()],
             ],
             [
-                "Test that a named parameter can be re-used",
+                "Test that a named parameter can be re-used consecutively",
                 'PI is approximately 3.14159, or 3.14159265 if you need more accuracy',
                 'PI is approximately %(pi).5f, or %(pi).8f if you need more accuracy',
                 ['pi' => pi()],
+            ],
+            [
+                "Test that a named parameter can be re-used inconsecutively",
+                'The name is Bond, James Bond.',
+                'The name is %(last_name)s, %(first_name)s %(last_name)s.',
+                ['first_name' => 'James', 'last_name' => 'Bond'],
             ],
             [
                 "Test that a named parameter can contain a dash",
@@ -74,9 +107,15 @@ class SprintfTest extends PHPUnit_Framework_TestCase
             ],
             [
                 "Test that the % sign can be escaped",
-                'x%(y-z)=0',
-                'x%%(y-z)=0',
-                [],
+                'x%(y-z)s=0',
+                'x%%(y-z)s=0',
+                ['y-z' => 5],
+            ],
+            [
+                "Test that the unescaped version is formatted",
+                'x5=0',
+                'x%(y-z)s=0',
+                ['y-z' => 5],
             ],
             [
                 "Test that a % sign can be escaped immediately before a named parameter",
@@ -86,16 +125,61 @@ class SprintfTest extends PHPUnit_Framework_TestCase
             ],
             [
                 "Test that consecutive % signs can be escaped",
-                '%%(hi)',
-                '%%%%(hi)',
-                [],
+                '%%(hi)s',
+                '%%%%(hi)s',
+                ['hi' => 'bye'],
+            ],
+            [
+                "Test that formatting can still occur if consecutive % signs can be escaped",
+                '%bye',
+                '%%%(hi)s',
+                ['hi' => 'bye'],
             ],
             [
                 "Test that multiple, separate % signs can be escaped",
-                '%(hi there) ... %(hi)',
-                '%%(hi there) ... %%(hi)',
+                '%(hi there)s ... %(hi)s',
+                '%%(hi there)s ... %%(hi)s',
                 [],
             ],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function provideNamedToUnnamedTranslatedTestCases()
+    {
+        return [
+            ['%b', '%(value)b', '123456789'],
+            ['%c', '%(value)c', ord('M')],
+            ['%d', '%(value)d', '123456789'],
+            ['%e', '%(value)e', '123456789'],
+            ['%E', '%(value)E', '123456789'],
+            ['%f', '%(value)f', '123456789'],
+            ['%F', '%(value)F', '123456789'],
+            ['%g', '%(value)g', '123456789'],
+            ['%G', '%(value)G', '123456789'],
+            ['%o', '%(value)o', '123456789'],
+            ['%s', '%(value)s', '123456789'],
+            ['%u', '%(value)u', '123456789'],
+            ['%x', '%(value)x', '123456789'],
+            ['%X', '%(value)X', '123456789'],
+            ['%+d', '%(value)+d', 123],
+            ['%+d', '%(value)+d', -123],
+            ['%+f', '%(value)+f', 123.456],
+            ['%+f', '%(value)+f', -123.456],
+            ['%+.4f', '%(value)+.4f', 123.456],
+            ['%+.4f', '%(value)+.4f', -123.456],
+            ['%u', '%(value)u', 123],
+            ['%u', '%(value)u', -123],
+            ['(%12s)', '(%(value)12s)', 'Pad-me'],
+            ['(%-12s)', '(%(value)-12s)', 'Pad-me'],
+            ['(%012s)', '(%(value)012s)', 'Pad-me'],
+            ['(%-012s)', '(%(value)-012s)', 'Pad-me'],
+            ['(%\'.12s)', '(%(value)\'.12s)', 'Pad-me'],
+            ['(%\'.-12s)', '(%(value)\'.-12s)', 'Pad-me'],
+            ['(%\'.-12.12s)', '(%(value)\'.-12.12s)', 'Pad-me'],
+            ['(%\'.-12.12s)', '(%(value)\'.-12.12s)', 'Truncated-me-yet?'],
         ];
     }
 }


### PR DESCRIPTION
Previously '%(named-param)' was being prepared as a sprintf
directive, but since there was not a type specifier (e.g. '%s')
the directive was improperly converted to a solo '%'.