### PR TITLE
Move sprintf() implementation to non-static method

### DIFF
--- a/src/Processor.php
+++ b/src/Processor.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Lstr\Sprintf;
+
+class Processor
+{
+    /**
+     * @param string $format
+     * @param array $parameters
+     * @return string
+     * @throws Exception
+     */
+    public function sprintf($format, array $parameters)
+    {
+        $parsed_parameters = [];
+        $replacement_sets = [];
+        $matches = [];
+        $pattern = '
+            @
+                (
+                    (?:^|[^%])
+                    (?:%%)*%
+                ) # 1: the percent sign(s)
+                \( # literal open paren
+                    ([a-zA-Z_][a-zA-Z0-9_\-]*?) # 2: the name of the param
+                \) # literal close paren
+
+                (
+                    (?:
+                        # standard sprintf format. reference http://php.net/sprintf
+                        [+]?                # an optional +/- sign specifier
+
+                        (?:[ 0]|\'.)?       # an optional space/zero padding specifier or
+                                            # alternative padding character prefixed by a single quote
+
+                        [\-]?               # an optional alignment specifier
+                                            # ("-" for left-justified; right-justified otherwise)
+
+                        \d*                 # an optional width specifier
+
+                        (?:\.(?:.?\d+)?)?   # an optional precision specifier
+                                            # (a dot "." followed by an optional number, with an optional
+                                            # padding character in between the dot and the number)
+
+                        [bcdeEfFgGosuxX]    # the type specifier
+                    )?
+
+                ) # 3: the standard sprintf format
+            @mx
+        ';
+        if (preg_match_all($pattern, $format, $matches, PREG_SET_ORDER)) {
+            foreach ($matches as $match) {
+                $percent_signs = $match[1];
+                $named_param = $match[2];
+                $sprintf_format = $match[3];
+
+                // if it is not a valid sprintf directive, escape the %
+                if (!$sprintf_format) {
+                    $replacement_sets[$match[0]] = "{$percent_signs}%({$named_param})";
+                    continue;
+                }
+
+                if (!array_key_exists($named_param, $parameters)) {
+                    throw new Exception(
+                        "The '{$named_param}' parameter was in the format string but was not provided"
+                    );
+                }
+
+                $replacement_sets[$match[0]] = "{$percent_signs}{$sprintf_format}";
+                $parsed_parameters[] = $parameters[$named_param];
+            }
+        }
+
+        $searches = array_keys($replacement_sets);
+        $replacements = array_values($replacement_sets);
+        $parsed_format = str_replace($searches, $replacements, $format);
+
+        return vsprintf($parsed_format, $parsed_parameters);
+    }
+}

--- a/src/Sprintf.php
+++ b/src/Sprintf.php
@@ -5,6 +5,11 @@ namespace Lstr\Sprintf;
 class Sprintf
 {
     /**
+     * @var Processor
+     */
+    private static $processor;
+
+    /**
      * @param string $format
      * @param array $parameters
      * @return string
@@ -12,69 +17,20 @@ class Sprintf
      */
     public static function sprintf($format, array $parameters)
     {
-        $parsed_parameters = [];
-        $replacement_sets = [];
-        $matches = [];
-        $pattern = '
-            @
-                (
-                    (?:^|[^%])
-                    (?:%%)*%
-                ) # 1: the percent sign(s)
-                \( # literal open paren
-                    ([a-zA-Z_][a-zA-Z0-9_\-]*?) # 2: the name of the param 
-                \) # literal close paren
+        return self::getProcessor()->sprintf($format, $parameters);
+    }
 
-                (
-                    (?:
-                        # standard sprintf format. reference http://php.net/sprintf
-                        [+]?                # an optional +/- sign specifier
-
-                        (?:[ 0]|\'.)?       # an optional space/zero padding specifier or
-                                            # alternative padding character prefixed by a single quote
-
-                        [\-]?               # an optional alignment specifier
-                                            # ("-" for left-justified; right-justified otherwise)
-
-                        \d*                 # an optional width specifier
-
-                        (?:\.(?:.?\d+)?)?   # an optional precision specifier
-                                            # (a dot "." followed by an optional number, with an optional
-                                            # padding character in between the dot and the number)
-
-                        [bcdeEfFgGosuxX]    # the type specifier
-                    )?
-
-                ) # 3: the standard sprintf format
-            @mx
-        ';
-        if (preg_match_all($pattern, $format, $matches, PREG_SET_ORDER)) {
-            foreach ($matches as $match) {
-                $percent_signs = $match[1];
-                $named_param = $match[2];
-                $sprintf_format = $match[3];
-
-                // if it is not a valid sprintf directive, escape the %
-                if (!$sprintf_format) {
-                    $replacement_sets[$match[0]] = "{$percent_signs}%({$named_param})";
-                    continue;
-                }
-
-                if (!array_key_exists($named_param, $parameters)) {
-                    throw new Exception(
-                        "The '{$named_param}' parameter was in the format string but was not provided"
-                    );
-                }
-
-                $replacement_sets[$match[0]] = "{$percent_signs}{$sprintf_format}";
-                $parsed_parameters[] = $parameters[$named_param];
-            }
+    /**
+     * @return Processor
+     */
+    private static function getProcessor()
+    {
+        if (self::$processor) {
+            return self::$processor;
         }
 
-        $searches = array_keys($replacement_sets);
-        $replacements = array_values($replacement_sets);
-        $parsed_format = str_replace($searches, $replacements, $format);
+        self::$processor = new Processor();
 
-        return vsprintf($parsed_format, $parsed_parameters);
+        return self::$processor;
     }
 }


### PR DESCRIPTION
Moving the implementation to a non-static class will
allow for easier abstraction and enhancements