### PR TITLE
Allow for middleware to pre-process values

### DIFF
--- a/src/ParsedExpression.php
+++ b/src/ParsedExpression.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Lstr\Sprintf;
+
+class ParsedExpression
+{
+    /**
+     * @var string
+     */
+    private $parsed_format;
+
+    /**
+     * @var array
+     */
+    private $parameter_map;
+
+    /**
+     * @param string $parsed_format
+     * @param array $parameter_map
+     */
+    public function __construct($parsed_format, array $parameter_map)
+    {
+        $this->parsed_format = $parsed_format;
+        $this->parameter_map = $parameter_map;
+    }
+
+    /**
+     * @param array $parameters
+     * @param callable|null $middleware
+     * @return string
+     * @throws Exception
+     */
+    public function format(array $parameters, callable $middleware = null)
+    {
+        if (!$middleware) {
+            $middleware = function ($name, $value, array $options) {
+                return $value;
+            };
+        }
+
+        $parsed_parameters = [];
+        foreach ($this->parameter_map as $param_mapping) {
+            $param_name = $param_mapping['name'];
+
+            if (!array_key_exists($param_name, $parameters)) {
+                throw new Exception(
+                    "The '{$param_name}' parameter was in the format string but was not provided"
+                );
+            }
+
+            $parsed_parameters[] = $middleware($param_name, $parameters[$param_name], []);
+        }
+
+        return vsprintf($this->parsed_format, $parsed_parameters);
+    }
+}

--- a/src/ParsedExpression.php
+++ b/src/ParsedExpression.php
@@ -48,7 +48,12 @@ class ParsedExpression
                 );
             }
 
-            $parsed_parameters[] = $middleware($param_name, $parameters[$param_name], []);
+            $parsed_parameters[] = call_user_func(
+                $middleware,
+                $param_name,
+                $parameters[$param_name],
+                []
+            );
         }
 
         return vsprintf($this->parsed_format, $parsed_parameters);

--- a/src/Sprintf.php
+++ b/src/Sprintf.php
@@ -12,12 +12,12 @@ class Sprintf
     /**
      * @param string $format
      * @param array $parameters
+     * @param callable $middleware
      * @return string
-     * @throws Exception
      */
-    public static function sprintf($format, array $parameters)
+    public static function sprintf($format, array $parameters, callable $middleware = null)
     {
-        return self::getProcessor()->sprintf($format, $parameters);
+        return self::getProcessor()->sprintf($format, $parameters, $middleware);
     }
 
     /**

--- a/tests/src/SprintfTest.php
+++ b/tests/src/SprintfTest.php
@@ -51,6 +51,28 @@ class SprintfTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function testMiddlewarePreprocessesValues()
+    {
+        $this->assertEquals(
+            "php bin/my-script 'config/config.php'",
+            Sprintf::sprintf(
+                'php %(script_path)s %(config_path)s',
+                [
+                    'script_path'   => 'bin/my-script',
+                    'config_path'   => 'config/config.php',
+                ],
+                function ($name, $value) {
+                    if ('script_path' === $name) {
+                        return $value;
+                    }
+
+                    return escapeshellarg($value);
+                }
+            ),
+            "Test that middleware can be provided to pre-process values"
+        );
+    }
+
     /**
      * @return array
      */


### PR DESCRIPTION
Middleware allows for all parameters to be processed
and replaced before being passed on to sprintf. An example
of where this is useful is if most or all parameters need
to have escapeshellarg() ran on them. Instead of running
escapeshellarg() manually on each parameter, middleware can
be passed in once and Sprintf::sprintf() can do the work
of calling it on each parameter.