### PR TITLE
Assume 's' sprintf type if sprintf format is blank

### DIFF
--- a/src/Processor.php
+++ b/src/Processor.php
@@ -57,8 +57,7 @@ class Processor
 
                 // if it is not a valid sprintf directive, escape the %
                 if (!$sprintf_format) {
-                    $replacement_sets[$match[0]] = "{$percent_signs}%({$named_param})";
-                    continue;
+                    $sprintf_format = 's';
                 }
 
                 $replacement_sets[$match[0]] = "{$percent_signs}{$sprintf_format}";

--- a/tests/src/SprintfTest.php
+++ b/tests/src/SprintfTest.php
@@ -87,15 +87,15 @@ class SprintfTest extends PHPUnit_Framework_TestCase
             ],
             [
                 "Test that named parameters are only recognized if sprintf directive is valid",
-                'Hello %(first_name) Light',
+                'Hello Matt Light',
                 'Hello %(first_name) %(last_name)s',
                 ['first_name' => 'Matt', 'last_name' => 'Light'],
             ],
             [
                 "Test that no parameters are required",
+                'Hello Matt',
                 'Hello %(first_name)',
-                'Hello %(first_name)',
-                [],
+                ['first_name' => 'Matt'],
             ],
             [
                 "Test that a floating point number can be formatted",


### PR DESCRIPTION
Rather than requiring the sprintf directive for simple
named params, assume a string type if the sprintf directive
is not provided.