### PR TITLE
Add support for commas and colons in param name

### DIFF
--- a/src/Processor.php
+++ b/src/Processor.php
@@ -23,7 +23,7 @@ class Processor
                     (?:%%)*%
                 ) # 1: the percent sign(s)
                 \( # literal open paren
-                    ([a-zA-Z_][a-zA-Z0-9_\-]*?) # 2: the name of the param
+                    ([a-zA-Z_][a-zA-Z0-9_\-,:]*?) # 2: the name of the param
                 \) # literal close paren
 
                 (

--- a/tests/src/SprintfTest.php
+++ b/tests/src/SprintfTest.php
@@ -163,6 +163,12 @@ class SprintfTest extends PHPUnit_Framework_TestCase
                 '%%(hi there)s ... %%(hi)s',
                 [],
             ],
+            [
+                "Test that param names can contain commas and colons",
+                'Tada!',
+                '%(hi:there-friend)s!',
+                ['hi:there-friend' => "Tada"],
+            ],
         ];
     }
 


### PR DESCRIPTION
This will allow the middleware to support parameter options