### PR TITLE
Move parameter lookup to middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ $middleware_message = Sprintf::sprintf(
         'action_words' => ['can', 'be', 'used'],
         'what'         => 'parameters',
     ],
-    function ($name, $value) {
+    function ($name, callable $values) {
+        $value = $values($name);
+
         if (is_array($value)) {
             return implode(' ', $value);
         }

--- a/src/ParsedExpression.php
+++ b/src/ParsedExpression.php
@@ -33,25 +33,29 @@ class ParsedExpression
     public function format(array $parameters, callable $middleware = null)
     {
         if (!$middleware) {
-            $middleware = function ($name, $value, array $options) {
-                return $value;
+            $middleware = function ($name, callable $values, array $options) {
+                return $values($name);
             };
         }
 
-        $parsed_parameters = [];
-        foreach ($this->parameter_map as $param_mapping) {
-            $param_name = $param_mapping['name'];
-
+        $values_callback = function ($param_name) use ($parameters) {
             if (!array_key_exists($param_name, $parameters)) {
                 throw new Exception(
                     "The '{$param_name}' parameter was in the format string but was not provided"
                 );
             }
 
+            return $parameters[$param_name];
+        };
+
+        $parsed_parameters = [];
+        foreach ($this->parameter_map as $param_mapping) {
+            $param_name = $param_mapping['name'];
+
             $parsed_parameters[] = call_user_func(
                 $middleware,
                 $param_name,
-                $parameters[$param_name],
+                $values_callback,
                 []
             );
         }

--- a/tests/src/SprintfTest.php
+++ b/tests/src/SprintfTest.php
@@ -61,7 +61,9 @@ class SprintfTest extends PHPUnit_Framework_TestCase
                     'script_path'   => 'bin/my-script',
                     'config_path'   => 'config/config.php',
                 ],
-                function ($name, $value) {
+                function ($name, callable $values) {
+                    $value = $values($name);
+
                     if ('script_path' === $name) {
                         return $value;
                     }


### PR DESCRIPTION
Some middleware may want to process the parameter name
before looking up the value associated with it. If we lookup
the parameter before calling the middleware, an exception saying
that a parameter does not exist may be thrown, so allow the
middleware to be responsible for the lookup via the $values()
callback