### PR TITLE
Add 'duplication' and 'fixme' Code Climate engines

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,11 @@
 engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+        - php
+  fixme:
+    enabled: true
   phpmd:
     enabled: true
     config:


### PR DESCRIPTION
The engines are normally on by default and the newly
introduced Code Climate config did not enable them