### PR TITLE
Add AbstractInvokable to support nested middleware

### DIFF
--- a/src/Middleware/AbstractInvokable.php
+++ b/src/Middleware/AbstractInvokable.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Lstr\Sprintf\Middleware;
+
+abstract class AbstractInvokable
+{
+    /**
+     * @var AbstractInvokable|null
+     */
+    private $invokable;
+
+    /**
+     * @param AbstractInvokable|null $invokable
+     */
+    public function __construct(AbstractInvokable $invokable = null)
+    {
+        $this->invokable = $invokable;
+    }
+
+    /**
+     * @param string $name
+     * @param callable $values
+     * @param array $options
+     * @return mixed
+     */
+    public function __invoke($name, callable $values, array $options)
+    {
+        $params = new InvokableParams($name, $values, $options);
+
+        $this->invokeProcess($params);
+        $values_callback = $params->getValuesCallback();
+
+        return $values_callback($params->getName());
+    }
+
+    /**
+     * @param InvokableParams $params
+     */
+    abstract protected function process(InvokableParams $params);
+
+    /**
+     * @param InvokableParams $params
+     */
+    private function invokeProcess(InvokableParams $params)
+    {
+        if ($this->invokable) {
+            call_user_func([$this->invokable, 'invokeProcess'], $params);
+        }
+
+        $this->process($params);
+    }
+}

--- a/src/Middleware/MiddlewareAdapter.php
+++ b/src/Middleware/MiddlewareAdapter.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Lstr\Sprintf\Middleware;
+
+class MiddlewareAdapter extends AbstractInvokable
+{
+    /**
+     * @var callable
+     */
+    private $middleware;
+
+    /**
+     * @param callable $middleware
+     * @param AbstractInvokable|null $invokable
+     */
+    public function __construct(callable $middleware, AbstractInvokable $invokable = null)
+    {
+        parent::__construct($invokable);
+
+        $this->middleware = $middleware;
+    }
+
+    /**
+     * @param InvokableParams $params
+     */
+    protected function process(InvokableParams $params)
+    {
+        $params->setValue(call_user_func(
+            $this->middleware,
+            $params->getName(),
+            $params->getValuesCallback(),
+            $params->getOptions()
+        ));
+    }
+}

--- a/tests/src/Middleware/MiddlewareAdapterTest.php
+++ b/tests/src/Middleware/MiddlewareAdapterTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Lstr\Sprintf\Middleware;
+
+use PHPUnit_Framework_TestCase;
+
+class MiddlewareAdapterTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers Lstr\Sprintf\Middleware\AbstractInvokable::__construct
+     * @covers Lstr\Sprintf\Middleware\MiddlewareAdapter::__invoke
+     * @covers Lstr\Sprintf\Middleware\MiddlewareAdapter::invokeProcess
+     * @covers Lstr\Sprintf\Middleware\MiddlewareAdapter::__construct
+     * @covers Lstr\Sprintf\Middleware\MiddlewareAdapter::process
+     */
+    public function testMiddlewareAdapterCallbackIsAppliedToValue()
+    {
+        $meta_adapter = $this->getMetaMiddlewareAdapter();
+        $values_callback = $this->getValuesCallback();
+
+        $this->assertEquals(
+            "abc:cba:123",
+            call_user_func($meta_adapter, 'abc', $values_callback, ['type' => 123])
+        );
+    }
+
+    /**
+     * @covers Lstr\Sprintf\Middleware\AbstractInvokable::__construct
+     * @covers Lstr\Sprintf\Middleware\MiddlewareAdapter::__invoke
+     * @covers Lstr\Sprintf\Middleware\MiddlewareAdapter::invokeProcess
+     * @covers Lstr\Sprintf\Middleware\MiddlewareAdapter::__construct
+     * @covers Lstr\Sprintf\Middleware\MiddlewareAdapter::process
+     */
+    public function testMiddlewareAdapterCallbackCanBeNested()
+    {
+        $repeat_adapter = $this->getRepeatMiddlewareAdapter();
+        $meta_adapter = $this->getMetaMiddlewareAdapter($repeat_adapter);
+        $values_callback = $this->getValuesCallback();
+
+        $this->assertEquals(
+            "abc:cbacbacba:123",
+            call_user_func($meta_adapter, 'abc', $values_callback, ['type' => 123, 'repeat' => 3])
+        );
+    }
+
+    /**
+     * @return callback
+     */
+    private function getValuesCallback()
+    {
+        return function ($name) {
+            return strrev($name);
+        };
+    }
+
+    /**
+     * @param MiddlewareAdapter $parent_middleware
+     * @return MiddlewareAdapter
+     */
+    private function getRepeatMiddlewareAdapter(MiddlewareAdapter $parent_middleware = null)
+    {
+        return new MiddlewareAdapter(function ($name, callable $values_callback, $options) {
+            return str_repeat($values_callback($name), $options['repeat']);
+        }, $parent_middleware);
+    }
+
+    /**
+     * @param MiddlewareAdapter|null $parent_middleware
+     * @return MiddlewareAdapter
+     */
+    private function getMetaMiddlewareAdapter(MiddlewareAdapter $parent_middleware = null)
+    {
+        return new MiddlewareAdapter(function ($name, callable $values_callback, $options) {
+            return "{$name}:" . $values_callback($name) . ":" . $options['type'];
+        }, $parent_middleware);
+    }
+}

--- a/tests/src/Middleware/MiddlewareAdapterTest.php
+++ b/tests/src/Middleware/MiddlewareAdapterTest.php
@@ -8,8 +8,8 @@ class MiddlewareAdapterTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @covers Lstr\Sprintf\Middleware\AbstractInvokable::__construct
-     * @covers Lstr\Sprintf\Middleware\MiddlewareAdapter::__invoke
-     * @covers Lstr\Sprintf\Middleware\MiddlewareAdapter::invokeProcess
+     * @covers Lstr\Sprintf\Middleware\AbstractInvokable::__invoke
+     * @covers Lstr\Sprintf\Middleware\AbstractInvokable::invokeProcess
      * @covers Lstr\Sprintf\Middleware\MiddlewareAdapter::__construct
      * @covers Lstr\Sprintf\Middleware\MiddlewareAdapter::process
      */
@@ -26,8 +26,8 @@ class MiddlewareAdapterTest extends PHPUnit_Framework_TestCase
 
     /**
      * @covers Lstr\Sprintf\Middleware\AbstractInvokable::__construct
-     * @covers Lstr\Sprintf\Middleware\MiddlewareAdapter::__invoke
-     * @covers Lstr\Sprintf\Middleware\MiddlewareAdapter::invokeProcess
+     * @covers Lstr\Sprintf\Middleware\AbstractInvokable::__invoke
+     * @covers Lstr\Sprintf\Middleware\AbstractInvokable::invokeProcess
      * @covers Lstr\Sprintf\Middleware\MiddlewareAdapter::__construct
      * @covers Lstr\Sprintf\Middleware\MiddlewareAdapter::process
      */


### PR DESCRIPTION
MiddlewareAdapter takes a callback (that the MiddlewareAdapter
is "adapting" to the AbstractInvokable) and an optional "parent"
AbstractInvokable.  The parent is processed before the child.