### PR TITLE
Make invokeProcess() available to children

### DIFF
--- a/src/Middleware/AbstractInvokable.php
+++ b/src/Middleware/AbstractInvokable.php
@@ -41,7 +41,7 @@ abstract class AbstractInvokable
     /**
      * @param InvokableParams $params
      */
-    private function invokeProcess(InvokableParams $params)
+    protected function invokeProcess(InvokableParams $params)
     {
         if ($this->invokable) {
             call_user_func([$this->invokable, 'invokeProcess'], $params);


### PR DESCRIPTION
AbstractInvokable Middleware will be able to more easily use
composition of middleware within their process() methods if
we allow invokeProcess() to be ran.