### PR TITLE
Rename LongOpts to LongOptions

### DIFF
--- a/src/Middleware/Cli/LongOptions.php
+++ b/src/Middleware/Cli/LongOptions.php
@@ -5,7 +5,7 @@ namespace Lstr\Sprintf\Middleware\Cli;
 use Lstr\Sprintf\Middleware\AbstractInvokable;
 use Lstr\Sprintf\Middleware\InvokableParams;
 
-class LongOpts extends AbstractInvokable
+class LongOptions extends AbstractInvokable
 {
     /**
      * @param InvokableParams $params
@@ -14,7 +14,7 @@ class LongOpts extends AbstractInvokable
     {
         $name = $params->getName();
 
-        if ('long-opts' !== $params->getOption('type', $name)) {
+        if ('long-options' !== $params->getOption('type', $name)) {
             return;
         }
 

--- a/tests/src/Middleware/Cli/LongOptionsTest.php
+++ b/tests/src/Middleware/Cli/LongOptionsTest.php
@@ -4,17 +4,17 @@ namespace Lstr\Sprintf\Middleware\Cli;
 
 use PHPUnit_Framework_TestCase;
 
-class LongOptsTest extends PHPUnit_Framework_TestCase
+class LongOptionsTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @covers Lstr\Sprintf\Middleware\Cli\LongOpts::process
-     * @dataProvider provideNotLongOpts
+     * @covers Lstr\Sprintf\Middleware\Cli\LongOptions::process
+     * @dataProvider provideNotLongOptions
      * @param string $name
      * @param array $options
      */
-    public function testValueRemainsUnchangedIfTypeIsNotLongOpts($name, array $options)
+    public function testValueRemainsUnchangedIfTypeIsNotLongOptions($name, array $options)
     {
-        $long_opts = new LongOpts();
+        $long_opts = new LongOptions();
         $values_callback = $this->getValuesCallback();
 
         $this->assertSame(
@@ -24,60 +24,60 @@ class LongOptsTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Lstr\Sprintf\Middleware\Cli\LongOpts::process
-     * @covers Lstr\Sprintf\Middleware\Cli\LongOpts::<private>
+     * @covers Lstr\Sprintf\Middleware\Cli\LongOptions::process
+     * @covers Lstr\Sprintf\Middleware\Cli\LongOptions::<private>
      */
     public function testArrayOfOptionsAreConvertedToString()
     {
-        $long_opts = new LongOpts();
+        $long_opts = new LongOptions();
         $values_callback = $this->getValuesCallback();
 
         $this->assertSame(
             "--username='light' --host='localhost' --force --name='\"awe'\''some\"'",
-            $long_opts("\"awe'some\"", $values_callback, ['type' => 'long-opts'])
+            $long_opts("\"awe'some\"", $values_callback, ['type' => 'long-options'])
         );
     }
 
     /**
-     * @covers Lstr\Sprintf\Middleware\Cli\LongOpts::process
-     * @covers Lstr\Sprintf\Middleware\Cli\LongOpts::<private>
+     * @covers Lstr\Sprintf\Middleware\Cli\LongOptions::process
+     * @covers Lstr\Sprintf\Middleware\Cli\LongOptions::<private>
      */
     public function testTypeCanBeImpliedFromName()
     {
-        $long_opts = new LongOpts();
+        $long_opts = new LongOptions();
         $values_callback = $this->getValuesCallback();
 
         $this->assertSame(
-            "--username='light' --host='localhost' --force --name='long-opts'",
-            $long_opts("long-opts", $values_callback, [])
+            "--username='light' --host='localhost' --force --name='long-options'",
+            $long_opts("long-options", $values_callback, [])
         );
     }
 
     /**
-     * @covers Lstr\Sprintf\Middleware\Cli\LongOpts::process
-     * @covers Lstr\Sprintf\Middleware\Cli\LongOpts::<private>
+     * @covers Lstr\Sprintf\Middleware\Cli\LongOptions::process
+     * @covers Lstr\Sprintf\Middleware\Cli\LongOptions::<private>
      */
     public function testStringIsUsedAsValue()
     {
-        $long_opts = new LongOpts();
+        $long_opts = new LongOptions();
 
         $this->assertSame(
             "--gogo='ogog'",
             $long_opts("gogo", function ($name) {
                 return strrev($name);
-            }, ['type' => 'long-opts'])
+            }, ['type' => 'long-options'])
         );
     }
 
     /**
      * @return array
      */
-    public function provideNotLongOpts()
+    public function provideNotLongOptions()
     {
         return [
             ['opts', []],
             ['opts', ['type' => 'custom-type']],
-            ['long-opts', ['type' => 'custom-type']],
+            ['long-options', ['type' => 'custom-type']],
         ];
     }
 


### PR DESCRIPTION
Abbreviations can be confusing and this abbreviation will
not save much typing routinely