### PR TITLE
Move duplicate-looking test code to datasets

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -4,6 +4,8 @@ engines:
     config:
       languages:
         - php
+    exclude_paths:
+      - "**.dataset.php"
   fixme:
     enabled: true
   phpmd:

--- a/tests/src/Middleware/Cli/OptionsTest.array.dataset.php
+++ b/tests/src/Middleware/Cli/OptionsTest.array.dataset.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Lstr\Sprintf\Middleware\Cli;
+
+use Lstr\Sprintf\Middleware\AbstractInvokable;
+
+return [
+    [
+        "~username:'light' ~host:'localhost' ~force ~name:'\"awe'\''some\"'",
+        'cool-options',
+        function (AbstractInvokable $invokable = null) {
+            return new Options('cool-options', $this->getCoolOptionsBuilder(), $invokable);
+        },
+        function () {
+            return ['username' => 'light', 'host' => 'localhost', 'force' => null, 'name' => "\"awe'some\""];
+        }
+    ],
+    [
+        "'light' 'localhost'  '\"awe'\''some\"'",
+        'args',
+        function (AbstractInvokable $invokable = null) {
+            return new Arguments($invokable);
+        },
+        function () {
+            return ['username' => 'light', 'host' => 'localhost', 'force' => null, 'name' => "\"awe'some\""];
+        }
+    ],
+    [
+        "--username='light' --host='localhost' --force --name='\"awe'\''some\"'",
+        'long-options',
+        function (AbstractInvokable $invokable = null) {
+            return new LongOptions($invokable);
+        },
+        function () {
+            return ['username' => 'light', 'host' => 'localhost', 'force' => null, 'name' => "\"awe'some\""];
+        }
+    ],
+    [
+        "-U 'light' -h 'localhost' -f -n '\"awe'\''some\"'",
+        'short-options',
+        function (AbstractInvokable $invokable = null) {
+            return new ShortOptions($invokable);
+        },
+        function () {
+            return ['U' => 'light', 'h' => 'localhost', 'f' => null, 'n' => "\"awe'some\""];
+        }
+    ],
+];

--- a/tests/src/Middleware/Cli/OptionsTest.php
+++ b/tests/src/Middleware/Cli/OptionsTest.php
@@ -159,48 +159,7 @@ class OptionsTest extends PHPUnit_Framework_TestCase
      */
     public function provideOptionConfigsForStringTest()
     {
-        return [
-            [
-                "~name:'\"awe'\''some\"'",
-                'cool-options',
-                function (AbstractInvokable $invokable = null) {
-                    return new Options('cool-options', $this->getCoolOptionsBuilder(), $invokable);
-                },
-                function () {
-                    return ['name' => "\"awe'some\""];
-                }
-            ],
-            [
-                "'\"awe'\''some\"'",
-                'args',
-                function (AbstractInvokable $invokable = null) {
-                    return new Arguments($invokable);
-                },
-                function () {
-                    return ['name' => "\"awe'some\""];
-                }
-            ],
-            [
-                "--name='\"awe'\''some\"'",
-                'long-options',
-                function (AbstractInvokable $invokable = null) {
-                    return new LongOptions($invokable);
-                },
-                function () {
-                    return ['name' => "\"awe'some\""];
-                }
-            ],
-            [
-                "-n '\"awe'\''some\"'",
-                'short-options',
-                function (AbstractInvokable $invokable = null) {
-                    return new ShortOptions($invokable);
-                },
-                function () {
-                    return ['n' => "\"awe'some\""];
-                }
-            ],
-        ];
+        return require __DIR__ . '/OptionsTest.string.dataset.php';
     }
 
     /**
@@ -208,48 +167,7 @@ class OptionsTest extends PHPUnit_Framework_TestCase
      */
     public function provideOptionConfigsForArrayTest()
     {
-        return [
-            [
-                "~username:'light' ~host:'localhost' ~force ~name:'\"awe'\''some\"'",
-                'cool-options',
-                function (AbstractInvokable $invokable = null) {
-                    return new Options('cool-options', $this->getCoolOptionsBuilder(), $invokable);
-                },
-                function () {
-                    return ['username' => 'light', 'host' => 'localhost', 'force' => null, 'name' => "\"awe'some\""];
-                }
-            ],
-            [
-                "'light' 'localhost'  '\"awe'\''some\"'",
-                'args',
-                function (AbstractInvokable $invokable = null) {
-                    return new Arguments($invokable);
-                },
-                function () {
-                    return ['username' => 'light', 'host' => 'localhost', 'force' => null, 'name' => "\"awe'some\""];
-                }
-            ],
-            [
-                "--username='light' --host='localhost' --force --name='\"awe'\''some\"'",
-                'long-options',
-                function (AbstractInvokable $invokable = null) {
-                    return new LongOptions($invokable);
-                },
-                function () {
-                    return ['username' => 'light', 'host' => 'localhost', 'force' => null, 'name' => "\"awe'some\""];
-                }
-            ],
-            [
-                "-U 'light' -h 'localhost' -f -n '\"awe'\''some\"'",
-                'short-options',
-                function (AbstractInvokable $invokable = null) {
-                    return new ShortOptions($invokable);
-                },
-                function () {
-                    return ['U' => 'light', 'h' => 'localhost', 'f' => null, 'n' => "\"awe'some\""];
-                }
-            ],
-        ];
+        return require __DIR__ . '/OptionsTest.array.dataset.php';
     }
 
     /**

--- a/tests/src/Middleware/Cli/OptionsTest.string.dataset.php
+++ b/tests/src/Middleware/Cli/OptionsTest.string.dataset.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Lstr\Sprintf\Middleware\Cli;
+
+use Lstr\Sprintf\Middleware\AbstractInvokable;
+
+return [
+    [
+        "~name:'\"awe'\''some\"'",
+        'cool-options',
+        function (AbstractInvokable $invokable = null) {
+            return new Options('cool-options', $this->getCoolOptionsBuilder(), $invokable);
+        },
+        function () {
+            return ['name' => "\"awe'some\""];
+        }
+    ],
+    [
+        "'\"awe'\''some\"'",
+        'args',
+        function (AbstractInvokable $invokable = null) {
+            return new Arguments($invokable);
+        },
+        function () {
+            return ['name' => "\"awe'some\""];
+        }
+    ],
+    [
+        "--name='\"awe'\''some\"'",
+        'long-options',
+        function (AbstractInvokable $invokable = null) {
+            return new LongOptions($invokable);
+        },
+        function () {
+            return ['name' => "\"awe'some\""];
+        }
+    ],
+    [
+        "-n '\"awe'\''some\"'",
+        'short-options',
+        function (AbstractInvokable $invokable = null) {
+            return new ShortOptions($invokable);
+        },
+        function () {
+            return ['n' => "\"awe'some\""];
+        }
+    ],
+];


### PR DESCRIPTION
The "duplicate code" is actually a test data set
represented in PHP