### PR TITLE
Remove obsolete comment about invalid sprintf directives

### DIFF
--- a/src/Processor.php
+++ b/src/Processor.php
@@ -55,7 +55,6 @@ class Processor
                 $named_param = $match[2];
                 $sprintf_format = $match[3];
 
-                // if it is not a valid sprintf directive, escape the %
                 if (!$sprintf_format) {
                     $sprintf_format = 's';
                 }


### PR DESCRIPTION
The comment was was before making sprintf directives optional