### PR TITLE
Enforce @covers annotations in unit tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,6 +7,7 @@
         convertErrorsToExceptions="true"
         convertNoticesToExceptions="true"
         convertWarningsToExceptions="true"
+        forceCoversAnnotation="true"
 >
 
     <testsuites>


### PR DESCRIPTION
Enforcing @covers prevents us from accidentally marking code as
covered when it was not intentionally being tested.