### PR TITLE
Move middleware injection to object level

### DIFF
--- a/src/Processor.php
+++ b/src/Processor.php
@@ -5,13 +5,20 @@ namespace Lstr\Sprintf;
 class Processor
 {
     /**
+     * @param callable|null $middleware
+     */
+    public function __construct(callable $middleware = null)
+    {
+        $this->middleware = $middleware;
+    }
+
+    /**
      * @param string $format
      * @param array $parameters
-     * @param callable $middleware
      * @return string
      * @throws Exception
      */
-    public function sprintf($format, array $parameters, callable $middleware = null)
+    public function sprintf($format, array $parameters)
     {
         $parameter_map = [];
         $replacement_sets = [];
@@ -72,6 +79,6 @@ class Processor
 
         $parsed_expression = new ParsedExpression($parsed_format, $parameter_map);
 
-        return $parsed_expression->format($parameters, $middleware);
+        return $parsed_expression->format($parameters, $this->middleware);
     }
 }

--- a/src/Sprintf.php
+++ b/src/Sprintf.php
@@ -5,27 +5,33 @@ namespace Lstr\Sprintf;
 class Sprintf
 {
     /**
+     * @var callable
+     */
+    private $middleware;
+
+    /**
      * @var Processor
      */
     private $processor;
 
     /**
+     * @param callable $middleware
      * @param Processor $processor
      */
-    public function __construct(Processor $processor = null)
+    public function __construct(callable $middleware = null, Processor $processor = null)
     {
+        $this->middleware = $middleware;
         $this->processor = $processor;
     }
 
     /**
      * @param string $format
      * @param array $parameters
-     * @param callable $middleware
      * @return string
      */
-    public function sprintf($format, array $parameters, callable $middleware = null)
+    public function sprintf($format, array $parameters)
     {
-        return $this->getProcessor()->sprintf($format, $parameters, $middleware);
+        return $this->getProcessor()->sprintf($format, $parameters);
     }
 
     /**
@@ -37,7 +43,7 @@ class Sprintf
             return $this->processor;
         }
 
-        $this->processor = new Processor();
+        $this->processor = new Processor($this->middleware);
 
         return $this->processor;
     }


### PR DESCRIPTION
Passing the middleware in at the object level will
allow the middleware to be re-used without having to
pass it in to each sprintf() call.