### PR TITLE
Fulfill formatting outside processor

### DIFF
--- a/src/Processor.php
+++ b/src/Processor.php
@@ -5,20 +5,11 @@ namespace Lstr\Sprintf;
 class Processor
 {
     /**
-     * @param callable|null $middleware
-     */
-    public function __construct(callable $middleware = null)
-    {
-        $this->middleware = $middleware;
-    }
-
-    /**
      * @param string $format
-     * @param array $parameters
-     * @return string
+     * @return ParsedExpression
      * @throws Exception
      */
-    public function sprintf($format, array $parameters)
+    public function parse($format)
     {
         $parameter_map = [];
         $replacement_sets = [];
@@ -79,6 +70,6 @@ class Processor
 
         $parsed_expression = new ParsedExpression($parsed_format, $parameter_map);
 
-        return $parsed_expression->format($parameters, $this->middleware);
+        return $parsed_expression;
     }
 }

--- a/src/Sprintf.php
+++ b/src/Sprintf.php
@@ -31,7 +31,9 @@ class Sprintf
      */
     public function sprintf($format, array $parameters)
     {
-        return $this->getProcessor()->sprintf($format, $parameters);
+        $parsed_expression = $this->getProcessor()->parse($format, $parameters);
+
+        return $parsed_expression->format($parameters, $this->middleware);
     }
 
     /**

--- a/tests/src/ProcessorTest.php
+++ b/tests/src/ProcessorTest.php
@@ -10,7 +10,7 @@ use PHPUnit_Framework_TestCase;
 class ProcessorTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @covers ::sprintf
+     * @covers ::parse
      * @dataProvider provideNamedParameterTestData
      * @param string $description
      * @param string $expected
@@ -21,16 +21,13 @@ class ProcessorTest extends PHPUnit_Framework_TestCase
     {
         $this->assertEquals(
             $expected,
-            $this->getProcessor()->sprintf(
-                $format,
-                $params
-            ),
+            $this->getProcessor()->parse($format)->format($params),
             $description
         );
     }
 
     /**
-     * @covers ::sprintf
+     * @covers ::parse
      * @dataProvider provideNamedToUnnamedTranslatedTestCases
      * @param string $unnamed_format
      * @param string $named_format
@@ -40,49 +37,8 @@ class ProcessorTest extends PHPUnit_Framework_TestCase
     {
         $this->assertEquals(
             sprintf($unnamed_format, $value),
-            $this->getProcessor()->sprintf($named_format, ['value' => $value]),
+            $this->getProcessor()->parse($named_format)->format(['value' => $value]),
             "Test that advanced cases can use format '{$named_format}'"
-        );
-    }
-
-    /**
-     * @covers ::sprintf
-     * @expectedException \Lstr\Sprintf\Exception
-     */
-    public function testUnprovidedNamedParametersThrowAnException()
-    {
-        $this->getProcessor()->sprintf(
-            'Hello %(missing_param)s',
-            ['full_name' => 'There']
-        );
-    }
-
-    /**
-     * @covers ::__construct
-     * @covers ::sprintf
-     */
-    public function testMiddlewarePreprocessesValues()
-    {
-        $middleware = function ($name, callable $values) {
-            $value = $values($name);
-
-            if ('script_path' === $name) {
-                return $value;
-            }
-
-            return escapeshellarg($value);
-        };
-
-        $this->assertEquals(
-            "php bin/my-script 'config/config.php'",
-            $this->getProcessor($middleware)->sprintf(
-                'php %(script_path)s %(config_path)s',
-                [
-                    'script_path' => 'bin/my-script',
-                    'config_path' => 'config/config.php',
-                ]
-            ),
-            "Test that middleware can be provided to pre-process values"
         );
     }
 


### PR DESCRIPTION
By moving the formatting fulfillment to Sprintf, the
processor can be renamed to parser