### PR TITLE
Stop passing middleware to Processor constructor

### DIFF
--- a/src/Sprintf.php
+++ b/src/Sprintf.php
@@ -45,7 +45,7 @@ class Sprintf
             return $this->processor;
         }
 
-        $this->processor = new Processor($this->middleware);
+        $this->processor = new Processor();
 
         return $this->processor;
     }


### PR DESCRIPTION
The middleware is no longer used by the processor.