### PR TITLE
Create ImpliedTypes middleware for setting type based on name

### DIFF
--- a/src/Middleware/ImpliedTypes.php
+++ b/src/Middleware/ImpliedTypes.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Lstr\Sprintf\Middleware;
+
+class ImpliedTypes extends AbstractInvokable
+{
+    /**
+     * @var array
+     */
+    private $implied_types;
+
+    /**
+     * @param array $implied_types
+     * @param AbstractInvokable|null $invokable
+     */
+    public function __construct(array $implied_types, AbstractInvokable $invokable = null)
+    {
+        parent::__construct($invokable);
+
+        $this->implied_types = $implied_types;
+    }
+
+    /**
+     * @param InvokableParams $params
+     */
+    protected function process(InvokableParams $params)
+    {
+        if (null !== $params->getOption('type')) {
+            return;
+        }
+
+        if (!array_key_exists($params->getName(), $this->implied_types)) {
+            return;
+        }
+
+        $params->setOption('type', $this->implied_types[$params->getName()]);
+    }
+}

--- a/tests/src/Middleware/ImpliedTypesTest.php
+++ b/tests/src/Middleware/ImpliedTypesTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Lstr\Sprintf\Middleware;
+
+use Exception;
+use PHPUnit_Framework_TestCase;
+
+class ImpliedTypesTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers Lstr\Sprintf\Middleware\ImpliedTypes::__construct
+     * @covers Lstr\Sprintf\Middleware\ImpliedTypes::process
+     */
+    public function testExplicitTypeIsLeftUnchanged()
+    {
+        $middleware = $this->getImpliedTypesMiddleware();
+        $values_callback = $this->getValuesCallback();
+
+        $this->assertParamType(
+            'explicit',
+            $middleware,
+            ['name' => 'param', 'values_callback' => $values_callback, 'options' => ['type' => 'explicit']]
+        );
+    }
+
+    /**
+     * @covers Lstr\Sprintf\Middleware\ImpliedTypes::__construct
+     * @covers Lstr\Sprintf\Middleware\ImpliedTypes::process
+     */
+    public function testImpliedTypeIsDefaulted()
+    {
+        $middleware = $this->getImpliedTypesMiddleware();
+        $values_callback = $this->getValuesCallback();
+
+        $this->assertParamType(
+            'short-options',
+            $middleware,
+            ['name' => 'short-options', 'values_callback' => $values_callback, 'options' => []]
+        );
+    }
+
+    /**
+     * @return callback
+     */
+    private function getValuesCallback()
+    {
+        return function ($name) {};
+    }
+
+    /**
+     * @param AbstractInvokable $parent_middleware
+     * @return AbstractInvokable
+     */
+    private function getImpliedTypesMiddleware(AbstractInvokable $parent_middleware = null)
+    {
+        return new ImpliedTypes(
+            [
+                'short-options' => 'short-options',
+                'long-options'  => 'long-options',
+            ],
+            $parent_middleware
+        );
+    }
+
+    /**
+     * @param string $expected
+     * @param AbstractInvokable $middleware
+     * @param array $params
+     */
+    private function assertParamType($expected, AbstractInvokable $middleware, array $params)
+    {
+        $assert_middleware = new MiddlewareAdapter(
+            function ($name, callable $values_callback, $options) use ($expected) {
+                $this->assertSame($expected, $options['type']);
+            },
+            $middleware
+        );
+
+        call_user_func($assert_middleware, $params['name'], $params['values_callback'], $params['options']);
+    }
+}


### PR DESCRIPTION
We want to default types for any params that do not have a type,
but first we want to imply any types that are known based on
param names