### PR TITLE
Change middle var names to be short but descriptive

### DIFF
--- a/tests/src/Middleware/DefaultTypeTest.php
+++ b/tests/src/Middleware/DefaultTypeTest.php
@@ -13,12 +13,12 @@ class DefaultTypeTest extends PHPUnit_Framework_TestCase
      */
     public function testExplicitTypeIsLeftUnchanged()
     {
-        $default_type_middleware = $this->getDefaultTypeMiddleware('default');
+        $default_type = $this->getDefaultTypeMiddleware('default');
         $values_callback = $this->getValuesCallback();
 
         $this->assertParamType(
             'explicit',
-            $default_type_middleware,
+            $default_type,
             ['name' => 'param', 'values_callback' => $values_callback, 'options' => ['type' => 'explicit']]
         );
     }
@@ -29,12 +29,12 @@ class DefaultTypeTest extends PHPUnit_Framework_TestCase
      */
     public function testMissingTypeIsDefaulted()
     {
-        $default_type_middleware = $this->getDefaultTypeMiddleware('default');
+        $default_type = $this->getDefaultTypeMiddleware('default');
         $values_callback = $this->getValuesCallback();
 
         $this->assertParamType(
             'default',
-            $default_type_middleware,
+            $default_type,
             ['name' => 'param', 'values_callback' => $values_callback, 'options' => []]
         );
     }

--- a/tests/src/Middleware/ImpliedTypesTest.php
+++ b/tests/src/Middleware/ImpliedTypesTest.php
@@ -13,12 +13,12 @@ class ImpliedTypesTest extends PHPUnit_Framework_TestCase
      */
     public function testExplicitTypeIsLeftUnchanged()
     {
-        $middleware = $this->getImpliedTypesMiddleware();
+        $implied_types = $this->getImpliedTypesMiddleware();
         $values_callback = $this->getValuesCallback();
 
         $this->assertParamType(
             'explicit',
-            $middleware,
+            $implied_types,
             ['name' => 'param', 'values_callback' => $values_callback, 'options' => ['type' => 'explicit']]
         );
     }
@@ -29,12 +29,12 @@ class ImpliedTypesTest extends PHPUnit_Framework_TestCase
      */
     public function testImpliedTypeIsDefaulted()
     {
-        $middleware = $this->getImpliedTypesMiddleware();
+        $implied_types = $this->getImpliedTypesMiddleware();
         $values_callback = $this->getValuesCallback();
 
         $this->assertParamType(
             'short-options',
-            $middleware,
+            $implied_types,
             ['name' => 'short-options', 'values_callback' => $values_callback, 'options' => []]
         );
     }

--- a/tests/src/Middleware/TypeCastTest.php
+++ b/tests/src/Middleware/TypeCastTest.php
@@ -12,12 +12,12 @@ class TypeCastTest extends PHPUnit_Framework_TestCase
      */
     public function testTypeCastMiddlewareIsAppliedToName()
     {
-        $type_cast_middleware = $this->getTypeCastMiddleware();
+        $type_cast = $this->getTypeCastMiddleware();
         $values_callback = $this->getValuesCallback();
 
         $this->assertSame(
             [100, 0, 0],
-            call_user_func($type_cast_middleware, 'red::color-graph', $values_callback, [])
+            call_user_func($type_cast, 'red::color-graph', $values_callback, [])
         );
     }
 
@@ -26,8 +26,8 @@ class TypeCastTest extends PHPUnit_Framework_TestCase
      */
     public function testTypeCastCanBeParent()
     {
-        $type_cast_middleware = $this->getTypeCastMiddleware();
-        $color_graph_middleware = $this->getColorGraphMiddleware($type_cast_middleware);
+        $type_cast = $this->getTypeCastMiddleware();
+        $color_graph_middleware = $this->getColorGraphMiddleware($type_cast);
         $values_callback = $this->getValuesCallback();
 
         $this->assertSame(
@@ -45,12 +45,12 @@ class TypeCastTest extends PHPUnit_Framework_TestCase
      */
     public function testTypeCastSetsTypeOption()
     {
-        $type_cast_middleware = $this->getTypeCastMiddleware();
+        $type_cast = $this->getTypeCastMiddleware();
         $values_callback = $this->getValuesCallback();
 
         $this->assertParams(
             ['name' => 'orange', 'value' => [100, 60, 0], 'options' => ['type' => 'color-graph']],
-            $type_cast_middleware,
+            $type_cast,
             ['name' => 'orange::color-graph', 'values_callback' => $values_callback, 'options' => []]
         );
     }
@@ -61,24 +61,24 @@ class TypeCastTest extends PHPUnit_Framework_TestCase
      */
     public function testTypeIsDefaultedToBlankByDefault()
     {
-        $type_cast_middleware = $this->getTypeCastMiddleware();
+        $type_cast = $this->getTypeCastMiddleware();
         $values_callback = $this->getValuesCallback();
 
         $this->assertParams(
             ['name' => 'orange', 'value' => [100, 60, 0], 'options' => ['type' => '']],
-            $type_cast_middleware,
+            $type_cast,
             ['name' => 'orange', 'values_callback' => $values_callback, 'options' => []]
         );
     }
 
     public function testDefaultTypeCanBeOverridden()
     {
-        $type_cast_middleware = $this->getTypeCastMiddleware('color-graph');
+        $type_cast = $this->getTypeCastMiddleware('color-graph');
         $values_callback = $this->getValuesCallback();
 
         $this->assertParams(
             ['name' => 'orange', 'value' => [100, 60, 0], 'options' => ['type' => 'color-graph']],
-            $type_cast_middleware,
+            $type_cast,
             ['name' => 'orange', 'values_callback' => $values_callback, 'options' => []]
         );
     }


### PR DESCRIPTION
phpmd is complaining about long names, but $middleware
seems a bit too generic since there may be multiple
middleware in the same method