### PR TITLE
Stop treating `null` default type as empty string

### DIFF
--- a/src/Middleware/TypeCast.php
+++ b/src/Middleware/TypeCast.php
@@ -17,7 +17,7 @@ class TypeCast extends AbstractInvokable
     {
         parent::__construct($invokable);
 
-        $this->default_type = (null === $default_type ? '' : $default_type);
+        $this->default_type = $default_type;
     }
 
     /**
@@ -28,6 +28,25 @@ class TypeCast extends AbstractInvokable
         $name = $params->getName();
         $name_parts = explode('::', $name, 2);
         $params->setName($name_parts[0]);
-        $params->setOption('type', (isset($name_parts[1]) ? $name_parts[1] : $this->default_type));
+
+        $type = $this->getType($name_parts);
+        if (null !== $type) {
+            $params->setOption('type', $type);
+        }
+    }
+
+    /**
+     * @param array $name_parts
+     * @return string|null
+     */
+    private function getType(array $name_parts)
+    {
+        if (isset($name_parts[1])) {
+            return $name_parts[1];
+        }
+
+        if (null !== $this->default_type) {
+            return $this->default_type;
+        }
     }
 }

--- a/tests/src/Middleware/TypeCastTest.php
+++ b/tests/src/Middleware/TypeCastTest.php
@@ -9,6 +9,7 @@ class TypeCastTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @covers Lstr\Sprintf\Middleware\TypeCast::process
+     * @covers Lstr\Sprintf\Middleware\TypeCast::<private>
      */
     public function testTypeCastMiddlewareIsAppliedToName()
     {
@@ -23,6 +24,7 @@ class TypeCastTest extends PHPUnit_Framework_TestCase
 
     /**
      * @covers Lstr\Sprintf\Middleware\TypeCast::process
+     * @covers Lstr\Sprintf\Middleware\TypeCast::<private>
      */
     public function testTypeCastCanBeParent()
     {
@@ -42,6 +44,7 @@ class TypeCastTest extends PHPUnit_Framework_TestCase
 
     /**
      * @covers Lstr\Sprintf\Middleware\TypeCast::process
+     * @covers Lstr\Sprintf\Middleware\TypeCast::<private>
      */
     public function testTypeCastSetsTypeOption()
     {
@@ -58,20 +61,26 @@ class TypeCastTest extends PHPUnit_Framework_TestCase
     /**
      * @covers Lstr\Sprintf\Middleware\TypeCast::__construct
      * @covers Lstr\Sprintf\Middleware\TypeCast::process
+     * @covers Lstr\Sprintf\Middleware\TypeCast::<private>
      */
-    public function testTypeIsDefaultedToBlankByDefault()
+    public function testTypeIsLeftUnsetIfNeitherATypeNorDefaultTypeIsDefined()
     {
         $type_cast = $this->getTypeCastMiddleware();
         $values_callback = $this->getValuesCallback();
 
         $this->assertParams(
-            ['name' => 'orange', 'value' => [100, 60, 0], 'options' => ['type' => '']],
+            ['name' => 'orange', 'value' => [100, 60, 0], 'options' => []],
             $type_cast,
             ['name' => 'orange', 'values_callback' => $values_callback, 'options' => []]
         );
     }
 
-    public function testDefaultTypeCanBeOverridden()
+    /**
+     * @covers Lstr\Sprintf\Middleware\TypeCast::__construct
+     * @covers Lstr\Sprintf\Middleware\TypeCast::process
+     * @covers Lstr\Sprintf\Middleware\TypeCast::<private>
+     */
+    public function testDefaultTypeCanBeSet()
     {
         $type_cast = $this->getTypeCastMiddleware('color-graph');
         $values_callback = $this->getValuesCallback();


### PR DESCRIPTION
If a parameter does not have a type and the type cast
middleware was not provided a type to use as the default,
we cannot set the parameter's type to a blank string without
causing issues for other middleware that comes along later.

For example, if TypeCast is not provided a default type because
ImpliedTypes needs to process implied types first, but TypeCast
has set the type to a blank string, then ImpliedTypes will not be
able to imply the types based on parameter names because the
type would technically already be set.