### PR TITLE
Ensure implied types for short-options/long-options

### DIFF
--- a/src/Middleware/Cli/Bundle.php
+++ b/src/Middleware/Cli/Bundle.php
@@ -3,6 +3,8 @@
 namespace Lstr\Sprintf\Middleware\Cli;
 
 use Lstr\Sprintf\Middleware\AbstractInvokable;
+use Lstr\Sprintf\Middleware\DefaultType;
+use Lstr\Sprintf\Middleware\ImpliedTypes;
 use Lstr\Sprintf\Middleware\InvokableParams;
 use Lstr\Sprintf\Middleware\TypeCast;
 
@@ -30,8 +32,15 @@ class Bundle extends AbstractInvokable
             return $this->bundled_middleware;
         }
 
-        $type_cast = new TypeCast('args');
-        $long_opts = new LongOptions($type_cast);
+        $implied_types = [
+            'short-options' => 'short-options',
+            'long-options'  => 'long-options',
+        ];
+
+        $type_cast = new TypeCast();
+        $implied_types = new ImpliedTypes($implied_types, $type_cast);
+        $default_type = new DefaultType('args', $implied_types);
+        $long_opts = new LongOptions($default_type);
         $short_opts = new ShortOptions($long_opts);
         $arguments = new Arguments($short_opts);
 

--- a/tests/src/Middleware/Cli/BundleTest.php
+++ b/tests/src/Middleware/Cli/BundleTest.php
@@ -82,14 +82,31 @@ class BundleTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Lstr\Sprintf\Middleware\Cli\Bundle::process
+     * @covers Lstr\Sprintf\Middleware\Cli\Bundle::<private>
+     */
+    public function testTypeCanBeImplied()
+    {
+        $bundle = new Bundle();
+
+        $this->assertSame(
+            "--username='light'",
+            $bundle('long-options', $this->getValuesCallback(), [])
+        );
+    }
+
+    /**
      * @return callback
      */
     private function getValuesCallback()
     {
         return function ($name) {
             $values = [
-                'U'        => 'light',
-                'username' => 'light',
+                'U'            => 'light',
+                'username'     => 'light',
+                'long-options' => [
+                    'username' => 'light',
+                ],
             ];
             if (!isset($values[$name])) {
                 throw new Exception("Param named '{$name}' could not be found.");


### PR DESCRIPTION
TypeCast was setting the type for those options to 'args'
because anything without an explicit type was being defaulted
to 'args'. Instead of providing a default type to TypeCast,
after we TypeCast we first imply types and then default to
'args' if a parameter still has no type.