### PR TITLE
Remove TypeCast default type

### DIFF
--- a/src/Middleware/TypeCast.php
+++ b/src/Middleware/TypeCast.php
@@ -5,19 +5,11 @@ namespace Lstr\Sprintf\Middleware;
 class TypeCast extends AbstractInvokable
 {
     /**
-     * @var string
-     */
-    private $default_type;
-
-    /**
-     * @param string $default_type
      * @param AbstractInvokable|null $invokable
      */
-    public function __construct($default_type = null, AbstractInvokable $invokable = null)
+    public function __construct(AbstractInvokable $invokable = null)
     {
         parent::__construct($invokable);
-
-        $this->default_type = $default_type;
     }
 
     /**
@@ -43,10 +35,6 @@ class TypeCast extends AbstractInvokable
     {
         if (isset($name_parts[1])) {
             return $name_parts[1];
-        }
-
-        if (null !== $this->default_type) {
-            return $this->default_type;
         }
     }
 }

--- a/tests/src/Middleware/TypeCastTest.php
+++ b/tests/src/Middleware/TypeCastTest.php
@@ -76,23 +76,6 @@ class TypeCastTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Lstr\Sprintf\Middleware\TypeCast::__construct
-     * @covers Lstr\Sprintf\Middleware\TypeCast::process
-     * @covers Lstr\Sprintf\Middleware\TypeCast::<private>
-     */
-    public function testDefaultTypeCanBeSet()
-    {
-        $type_cast = $this->getTypeCastMiddleware('color-graph');
-        $values_callback = $this->getValuesCallback();
-
-        $this->assertParams(
-            ['name' => 'orange', 'value' => [100, 60, 0], 'options' => ['type' => 'color-graph']],
-            $type_cast,
-            ['name' => 'orange', 'values_callback' => $values_callback, 'options' => []]
-        );
-    }
-
-    /**
      * @return callback
      */
     private function getValuesCallback()
@@ -113,13 +96,12 @@ class TypeCastTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param string $default_type
      * @param AbstractInvokable $parent_middleware
      * @return AbstractInvokable
      */
-    private function getTypeCastMiddleware($default_type = null, AbstractInvokable $parent_middleware = null)
+    private function getTypeCastMiddleware(AbstractInvokable $parent_middleware = null)
     {
-        return new TypeCast($default_type, $parent_middleware);
+        return new TypeCast($parent_middleware);
     }
 
     /**


### PR DESCRIPTION
The default type can be set by chaining the DefaultType
middleware after the TypeCast middleware