### PR TITLE
Simplify TypeCast middleware implementation

### DIFF
--- a/src/Middleware/TypeCast.php
+++ b/src/Middleware/TypeCast.php
@@ -5,14 +5,6 @@ namespace Lstr\Sprintf\Middleware;
 class TypeCast extends AbstractInvokable
 {
     /**
-     * @param AbstractInvokable|null $invokable
-     */
-    public function __construct(AbstractInvokable $invokable = null)
-    {
-        parent::__construct($invokable);
-    }
-
-    /**
      * @param InvokableParams $params
      */
     protected function process(InvokableParams $params)
@@ -21,20 +13,8 @@ class TypeCast extends AbstractInvokable
         $name_parts = explode('::', $name, 2);
         $params->setName($name_parts[0]);
 
-        $type = $this->getType($name_parts);
-        if (null !== $type) {
-            $params->setOption('type', $type);
-        }
-    }
-
-    /**
-     * @param array $name_parts
-     * @return string|null
-     */
-    private function getType(array $name_parts)
-    {
         if (isset($name_parts[1])) {
-            return $name_parts[1];
+            $params->setOption('type', $name_parts[1]);
         }
     }
 }


### PR DESCRIPTION
After removing the `$default_type` constructor argument:
 - The constructor is redundant
 - The getType() method is unnecessary complexity

Remove them both!