### PR TITLE
Switch PHP dev docker environment to Alpine

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,9 +1,16 @@
-FROM php:7.0
+FROM php:7.0-alpine
 
-RUN apt-get update && apt-get install -y git zip
-
-RUN pecl install xdebug-2.5.5 \
-  && docker-php-ext-enable xdebug
+RUN apk add --no-cache --virtual .phpize-deps \
+      $PHPIZE_DEPS \
+    && apk add --no-cache \
+        git \
+        zlib-dev \
+    && docker-php-ext-install \
+        bcmath \
+        zip \
+    && pecl install xdebug \
+    && docker-php-ext-enable xdebug \
+    && apk del --no-cache .phpize-deps
 
 RUN curl -sS https://getcomposer.org/installer >/usr/local/bin/composer-setup.php \
   && php /usr/local/bin/composer-setup.php \


### PR DESCRIPTION
The switch to Alpine is for the sake of image size