### PR TITLE
Switch regex to use nowdoc

### DIFF
--- a/src/Processor.php
+++ b/src/Processor.php
@@ -14,39 +14,39 @@ class Processor
         $parameter_map = [];
         $replacement_sets = [];
         $matches = [];
-        $pattern = '
-            @
-                (
-                    (?:^|[^%])
-                    (?:%%)*%
-                ) # 1: the percent sign(s)
-                \( # literal open paren
-                    ([a-zA-Z_][a-zA-Z0-9_\-,:]*?) # 2: the name of the param
-                \) # literal close paren
+        $pattern = <<<'REGEX'
+@
+    (
+        (?:^|[^%])
+        (?:%%)*%
+    ) # 1: the percent sign(s)
+    \( # literal open paren
+        ([a-zA-Z_][a-zA-Z0-9_\-,:]*?) # 2: the name of the param
+    \) # literal close paren
 
-                (
-                    (?:
-                        # standard sprintf format. reference http://php.net/sprintf
-                        [+]?                # an optional +/- sign specifier
+    (
+        (?:
+            # standard sprintf format. reference http://php.net/sprintf
+            [+]?                # an optional +/- sign specifier
 
-                        (?:[ 0]|\'.)?       # an optional space/zero padding specifier or
-                                            # alternative padding character prefixed by a single quote
+            (?:[ 0]|\'.)?       # an optional space/zero padding specifier or
+                                # alternative padding character prefixed by a single quote
 
-                        [\-]?               # an optional alignment specifier
-                                            # ("-" for left-justified; right-justified otherwise)
+            [\-]?               # an optional alignment specifier
+                                # ("-" for left-justified; right-justified otherwise)
 
-                        \d*                 # an optional width specifier
+            \d*                 # an optional width specifier
 
-                        (?:\.(?:.?\d+)?)?   # an optional precision specifier
-                                            # (a dot "." followed by an optional number, with an optional
-                                            # padding character in between the dot and the number)
+            (?:\.(?:.?\d+)?)?   # an optional precision specifier
+                                # (a dot "." followed by an optional number, with an optional
+                                # padding character in between the dot and the number)
 
-                        [bcdeEfFgGosuxX]    # the type specifier
-                    )?
+            [bcdeEfFgGosuxX]    # the type specifier
+        )?
 
-                ) # 3: the standard sprintf format
-            @mx
-        ';
+    ) # 3: the standard sprintf format
+@mx
+REGEX;
         if (preg_match_all($pattern, $format, $matches, PREG_SET_ORDER)) {
             foreach ($matches as $match) {
                 $percent_signs = $match[1];


### PR DESCRIPTION
In certain environments (such as http://sandbox.onlinephpfunctions.com/),
`preg_match` complains if the pattern string contains a newline after
the pattern modifiers.  Using a nowdoc suppresses the end-of-string
newline.

```
Warning:  preg_match(): Unknown modifier '
'
```

No tests are being included with this fix because I could not reproduce
the error in the Docker or Travis CI environments.

Resolves #61